### PR TITLE
Minor fixes and tweeks.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_LDLIBS := -llog
+
+LOCAL_MODULE    := F5Buffers
+LOCAL_SRC_FILES := src/main/jni/info_guardianproject_f5android_plugins_f5_F5Buffers.cpp
+
+
+include $(BUILD_SHARED_LIBRARY)
+

--- a/src/main/java/info/guardianproject/f5android/plugins/f5/Extract.java
+++ b/src/main/java/info/guardianproject/f5android/plugins/f5/Extract.java
@@ -83,7 +83,11 @@ public class Extract extends StegoProcessThread {
 		carrier = new byte[flength];
 		fis.read(carrier);
 
-		final HuffmanDecode hd = new HuffmanDecode(a, carrier, this);
+		HuffmanDecode hd = null;
+		try{
+			hd = new HuffmanDecode(a, carrier, this);
+		} catch(IOException e) {throw e;}
+
 		Log.d(Jpeg.LOG, "Huffman decoding starts");
 		//coeff = hd.decode();
 		int coeff_length = hd.decode();

--- a/src/main/java/info/guardianproject/f5android/plugins/f5/james/JpegEncoder.java
+++ b/src/main/java/info/guardianproject/f5android/plugins/f5/james/JpegEncoder.java
@@ -668,7 +668,7 @@ public class JpegEncoder {
 
 
 		// Comment Header
-
+        // Lie. Claim to be the product of a popular PHP jpeg lib to reduce suspicion.
         String comment = "CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 90\n  ";
 
         length = comment.length();

--- a/src/main/java/info/guardianproject/f5android/plugins/f5/james/JpegEncoder.java
+++ b/src/main/java/info/guardianproject/f5android/plugins/f5/james/JpegEncoder.java
@@ -87,22 +87,22 @@ public class JpegEncoder {
 		this.dct = new DCT(this.Quality);
 		this.Huf = new Huffman(this.imageWidth, this.imageHeight);
 		this.f5_seed = f5_seed;
-		
+
 	}
 
 	@SuppressWarnings("static-access")
 	public boolean Compress() {
 		Log.d(thread_monitor.LOG, "NOW COMPRESSING...");
-		
+
 		if(this.thread_monitor.isInterrupted()) { return false; }
 		WriteHeaders(this.outStream);
-		
+
 		if(this.thread_monitor.isInterrupted()) { return false; }
 		WriteCompressedData(this.outStream);
-		
+
 		if(this.thread_monitor.isInterrupted()) { return false; }
 		WriteEOI(this.outStream);
-		
+
 		if(this.thread_monitor.isInterrupted()) { return false; }
 		try {
 			this.outStream.flush();
@@ -191,7 +191,7 @@ public class JpegEncoder {
 				}
 			}
 		}
-		
+
 		if(this.thread_monitor.isInterrupted()) { return; }
 		this.JpegObj.f5.initF5Coeffs(coeffCount);
 
@@ -635,7 +635,7 @@ public class JpegEncoder {
 
 		// The order of the following headers is quiet inconsequential.
 		// the JFIF header
-		
+
 		final byte JFIF[] = new byte[18];
 		JFIF[0] = (byte) 0xff; // app0 marker
 		JFIF[1] = (byte) 0xe0;
@@ -662,15 +662,15 @@ public class JpegEncoder {
         }
 		 */
 
-        // NOT NECESSARY.
-		//WriteArray(JFIF, out);
+        // Not Necessary. Few JPEG encoder omit it.
+		// Conspicuous without.
+		WriteArray(JFIF, out);
 
-		// TODO: GET RID OF THIS, TOO
+
 		// Comment Header
 
-		/*
-        String comment = new String();
-        comment = this.JpegObj.getComment();
+        String comment = "CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 90\n  ";
+
         length = comment.length();
         if (length != 0) {
             final byte COM[] = new byte[length + 4];
@@ -678,10 +678,10 @@ public class JpegEncoder {
             COM[1] = (byte) 0xFE;
             COM[2] = (byte) (length >> 8 & 0xFF);
             COM[3] = (byte) (length & 0xFF);
-            java.lang.System.arraycopy(this.JpegObj.Comment.getBytes(), 0, COM, 4, this.JpegObj.Comment.length());
+            java.lang.System.arraycopy(comment.getBytes(), 0, COM, 4, comment.length());
             WriteArray(COM, out);
         }
-		 */
+
 
 		// The DQT header
 		// 0 is the luminance index and 1 is the chrominance index

--- a/src/main/java/info/guardianproject/f5android/plugins/f5/ortega/HuffmanDecode.java
+++ b/src/main/java/info/guardianproject/f5android/plugins/f5/ortega/HuffmanDecode.java
@@ -214,7 +214,8 @@ public class HuffmanDecode {
     // }}
 
     // Constructor Method
-    public HuffmanDecode(Activity a, final byte[] data, StegoProcessThread thread_monitor) {
+    public HuffmanDecode(Activity a, final byte[] data, StegoProcessThread thread_monitor)
+            throws IOException {
     	f5 = new F5Buffers(a);
     	this.thread_monitor = thread_monitor;
     	
@@ -228,6 +229,8 @@ public class HuffmanDecode {
                 case 192:
                     sof0();
                     break;
+                case 194: // sof2
+                    throw new IOException("Progressive scan JPEGs not supported by decoder");
                 case 196:
                     dht();
                     break;


### PR DESCRIPTION
HuffmanDecode.java
Fixed: HuffmanDecode now throws Exception instead of hanging if given a progressive-scan JPEG to decode.
Used to give that ""Nf weder 1 noch 3" error. (JpegEncoder only makes baseline JPEGS. So it can't contain F5 hidden data.)

JpegEncoder.java
Restored the JFIF header. Very few encoders do not write it. Files without it are conspicuous. Not what you want from stegano.
Added a default comment claiming to be from a popular PHP jpeg lib to further throw off suspicion.

Embed.java
Exception catch